### PR TITLE
Fix conservative polviews to 5-7

### DIFF
--- a/01_clean.ipynb
+++ b/01_clean.ipynb
@@ -1866,7 +1866,7 @@
     "    make_boolean(df, 'income', [1,2,3,4,5,6,7,8], 'lowincome')\n",
     "    make_boolean(df, 'polviews', [1,2,3], 'liberal')\n",
     "    make_boolean(df, 'polviews', [4], 'moderate')\n",
-    "    make_boolean(df, 'polviews', [6,7,8], 'conservative')\n",
+    "    make_boolean(df, 'polviews', [5,6,7], 'conservative')\n",
     "    make_boolean(df, 'sex', [2], 'female')\n",
     "    make_boolean(df, 'hispanic', [2], 'ishisp')\n",
     "    make_boolean(df, 'race', [2], 'black')\n",


### PR DESCRIPTION
I doubt this impacts the findings in a meaningful way, but as far as I can tell the ints were chosen wrong for the conservative grouping - should be 5, 6, and 7 The link in the notebook didn't work for me but this looks similar: https://gssdataexplorer.norc.org/variables/178/vshow

